### PR TITLE
Fix cleanup: false never honored

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ class PythonIndividually {
         return true;
       } else if (cliOption[disable]) {
         return false;
-      } else if (yamlOption[key]) {
+      } else if (key in yamlOption) {
         return yamlOption[key];
       }
       return origin;


### PR DESCRIPTION
If yamlOption[key] is false, updater will always return the default value for key. For cleanup, the default is true. That means the plugin won't honor cleanup: false in serverless.yaml.
Instead, check for the existence of they key in the yaml file.