### PR TITLE
fix path creation for docker invocation

### DIFF
--- a/index.js
+++ b/index.js
@@ -263,14 +263,14 @@ def handler(event, context):
       if (dockerized) {
         return ['docker', 'run', '-v', process.cwd() + ':/var/task',
           'lambci/lambda:build-python2.7', 'python',
-          Path.join(dir, libDir, '_requirements.py'),
-          Path.join(dir, 'requirements.txt'),
-          Path.join(dir, libDir)];
+          Path.posix.join(dir, libDir, '_requirements.py'),
+          Path.posix.join(dir, 'requirements.txt'),
+          Path.posix.join(dir, libDir)];
       } else {
         return ['python',
-          Path.join(dir, libDir, '_requirements.py'),
-          Path.join(dir, 'requirements.txt'),
-          Path.join(dir, libDir)];
+          Path.posix.join(dir, libDir, '_requirements.py'),
+          Path.posix.join(dir, 'requirements.txt'),
+          Path.posix.join(dir, libDir)];
       }
     })(this.dockerizedPip);
 


### PR DESCRIPTION
On Windows the following error is thrown when using Docker:
```
Serverless: [pyIndividually] Installing packagings: docker run -v C:\Users\felix_schroeter\Documents\Projects\eAccounting-server:/var/task lambci/lambda:build-python2.7 python src\stepfunction\preprocess\lib\
_requirements.py src\stepfunction\preprocess\requirements.txt src\stepfunction\preprocess\lib
Serverless: [pyIndividually] python: can't open file 'src\stepfunction\preprocess\lib\_requirements.py': [Errno 22] Invalid argument
```

This happens because the provided paths use backslahes although they are not supported in this case.