### PR TITLE
Pick docker image based on runtime

### DIFF
--- a/index.js
+++ b/index.js
@@ -262,8 +262,9 @@ def handler(event, context):
   install(dir, libDir) {
     const cmd = ((dockerized) => {
       if (dockerized) {
+        const runtime = this.serverless.service.provider.runtime;
         return ['docker', 'run', '-v', process.cwd() + ':/var/task',
-          'lambci/lambda:build-python2.7', 'python',
+          'lambci/lambda:build-' + runtime, 'python',
           Path.posix.join(dir, libDir, '_requirements.py'),
           Path.posix.join(dir, 'requirements.txt'),
           Path.posix.join(dir, libDir)];


### PR DESCRIPTION
The `dockerizedPip` option currently always pulls the python2.7 image. This PR changes the behavior to adjust the image name based on the runtime set in the `serverless.yml`.

This change requires https://github.com/lambci/docker-lambda/pull/46 to fully work with python3.6, as the current lambci/lambda image misses `virtualenv`.

Please have a look.